### PR TITLE
Calculate node fill pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   of the underlying node implementation, which requires dimensions that are square and powers of two.
 * Refactor shapes to be represented in unsigned space.
 * Add `PixelMap::contour` method to obtain a list of line segments that contour a shape.
+* Add `PNode::node_fill_profile(...) -> PNodeFill` for better understanding how a node is populated
+  with pixel data.
+* Allow more advanced tree navigation by producing a `PNodeFill` from a `PixelMap::visit_nodes_in_rect`
+  visitor closure, rather than a `bool`, which controls child node visitation.
 
 ## v0.2.0
 

--- a/src/pixel_map.rs
+++ b/src/pixel_map.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::{ICircle, PNode, RayCast, RayCastContext, RayCastQuery, RayCastResult, Region};
-use crate::{urect_points, NeighborOrientation, NodePath, Shape, ULine};
+use crate::{urect_points, NeighborOrientation, NodePath, PNodeFill, Shape, ULine};
 use bevy_math::{uvec2, IVec2, URect, UVec2};
 use num_traits::{NumCast, Unsigned};
 use std::collections::HashSet;
@@ -303,8 +303,8 @@ impl<T: Copy + PartialEq, U: Unsigned + NumCast + Copy + Debug> PixelMap<T, U> {
     /// - `rect`: The rectangle in which contained or overlapping nodes will be visited.
     /// - `visitor`: A closure that takes a reference to a node, and a reference to a
     ///   rectangle as parameters. This rectangle represents the intersection of the node's
-    ///   region and the `rect` parameter supplied to this method. It returns `true` if the
-    ///   node's children should be visited, or `false` otherwise.
+    ///   region and the `rect` parameter supplied to this method. It returns a [PNodeFill]
+    ///   that denotes which child nodes should be visited.
     ///
     /// # Returns
     ///
@@ -312,7 +312,7 @@ impl<T: Copy + PartialEq, U: Unsigned + NumCast + Copy + Debug> PixelMap<T, U> {
     #[inline]
     pub fn visit_nodes_in_rect<F>(&self, rect: &URect, mut visitor: F) -> u32
     where
-        F: FnMut(&PNode<T, U>, &URect) -> bool,
+        F: FnMut(&PNode<T, U>, &URect) -> PNodeFill,
     {
         let rect = rect.intersect(self.map_rect());
         if rect.is_empty() {
@@ -603,7 +603,7 @@ impl<T: Copy + PartialEq, U: Unsigned + NumCast + Copy + Debug> PixelMap<T, U> {
                         stats.unit_count += 1;
                     }
                 }
-                true
+                PNodeFill::Full
             },
             &mut 0,
         );

--- a/src/pnode.rs
+++ b/src/pnode.rs
@@ -198,10 +198,7 @@ impl<T: Copy + PartialEq, U: Unsigned + NumCast + Copy + Debug> PNode<T, U> {
 
     /// If a rectangle can contour the given `fill` pattern without gaps, return that rectangle
     /// representation for this node's region. Otherwise, return `None`.
-    pub fn node_fill_rect(
-        &self,
-        fill: PNodeFill,
-    ) -> Option<URect> {
+    pub fn node_fill_rect(&self, fill: PNodeFill) -> Option<URect> {
         if let Some(q) = fill.quadrant() {
             return Some(self.children()[q as usize].region().into());
         }

--- a/src/pnode.rs
+++ b/src/pnode.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use super::{ICircle, RayCast, RayCastContext, RayCastQuery, RayCastResult, Region};
-use crate::{distance_to, exclusive_urect, NodePath, Quadrant};
+use crate::{distance_to, exclusive_urect, NodePath, PNodeFill, Quadrant};
 use bevy_math::{URect, UVec2};
 use num_traits::{NumCast, Unsigned};
 use std::fmt::Debug;
@@ -130,27 +130,127 @@ impl<T: Copy + PartialEq, U: Unsigned + NumCast + Copy + Debug> PNode<T, U> {
     #[inline]
     #[must_use]
     pub fn is_leaf_parent(&self) -> bool {
-        return match &self.kind {
+        match &self.kind {
             PNodeKind::Leaf(_) => false,
             PNodeKind::Branch(children) => children.iter().all(|c| c.is_leaf()),
-        };
+        }
+    }
+
+    /// Determine how the node is filled (i.e. how child nodes are stored) based on the
+    /// given `predicate` closure.
+    ///
+    /// # Leaf Nodes
+    ///
+    /// A leaf node will be considered [PNodeFill::Full] if the predicate
+    /// returns `true` for that node, otherwise [PNodeFill::Empty].
+    ///
+    /// # Branch Nodes
+    ///
+    /// A branch node will produce a [PNodeFill] that reflects the quadrant(s) that are leaf nodes
+    /// and pass the predicate. In other words, any quadrants that are not represented by
+    /// the returned [PNodeFill] are either a complex sub-tree of nodes, or do not pass the
+    /// predicate.
+    pub fn node_fill_profile<F>(&self, mut predicate: F) -> PNodeFill
+    where
+        F: FnMut(&PNode<T, U>) -> bool,
+    {
+        if self.is_leaf() {
+            if predicate(self) {
+                PNodeFill::Full
+            } else {
+                PNodeFill::Empty
+            }
+        } else {
+            let children = self.children();
+
+            let mut check_quadrant = |q: Quadrant| {
+                let child = &children[q as usize];
+                child.is_leaf() && predicate(child)
+            };
+
+            let (bl, br, tl, tr) = (
+                check_quadrant(Quadrant::BottomLeft),
+                check_quadrant(Quadrant::BottomRight),
+                check_quadrant(Quadrant::TopLeft),
+                check_quadrant(Quadrant::TopRight),
+            );
+
+            match (bl, br, tl, tr) {
+                (true, true, true, true) => PNodeFill::Full,
+                (false, false, false, false) => PNodeFill::Empty,
+                (true, false, false, false) => PNodeFill::BottomLeft,
+                (false, true, false, false) => PNodeFill::BottomRight,
+                (false, false, true, false) => PNodeFill::TopLeft,
+                (false, false, false, true) => PNodeFill::TopRight,
+                (true, true, false, false) => PNodeFill::Bottom,
+                (false, false, true, true) => PNodeFill::Top,
+                (true, false, true, false) => PNodeFill::Left,
+                (false, true, false, true) => PNodeFill::Right,
+                (true, false, false, true) => PNodeFill::BottomLeftTopRight,
+                (false, true, true, false) => PNodeFill::BottomRightTopLeft,
+                (false, true, true, true) => PNodeFill::NotBottomLeft,
+                (true, false, true, true) => PNodeFill::NotBottomRight,
+                (true, true, false, true) => PNodeFill::NotTopLeft,
+                (true, true, true, false) => PNodeFill::NotTopRight,
+            }
+        }
+    }
+
+    /// If a rectangle can contour the given `fill` pattern without gaps, return that rectangle
+    /// representation for this node's region. Otherwise, return `None`.
+    pub fn node_fill_rect(
+        &self,
+        fill: PNodeFill,
+    ) -> Option<URect> {
+        if let Some(q) = fill.quadrant() {
+            return Some(self.children()[q as usize].region().into());
+        }
+        match fill {
+            PNodeFill::Full => Some(self.region().into()),
+            PNodeFill::Bottom => {
+                let children = self.children();
+                let bottom_left = children[Quadrant::BottomLeft as usize].region().as_urect();
+                let bottom_right = children[Quadrant::BottomRight as usize].region().as_urect();
+                Some(URect::from_corners(bottom_left.min, bottom_right.max))
+            }
+            PNodeFill::Top => {
+                let children = self.children();
+                let top_left = children[Quadrant::TopLeft as usize].region().as_urect();
+                let top_right = children[Quadrant::TopRight as usize].region().as_urect();
+                Some(URect::from_corners(top_left.min, top_right.max))
+            }
+            PNodeFill::Left => {
+                let children = self.children();
+                let bottom_left = children[Quadrant::BottomLeft as usize].region().as_urect();
+                let top_left = children[Quadrant::TopLeft as usize].region().as_urect();
+                Some(URect::from_corners(bottom_left.min, top_left.max))
+            }
+            PNodeFill::Right => {
+                let children = self.children();
+                let bottom_right = children[Quadrant::BottomRight as usize].region().as_urect();
+                let top_right = children[Quadrant::TopRight as usize].region().as_urect();
+                Some(URect::from_corners(bottom_right.min, top_right.max))
+            }
+            _ => None,
+        }
     }
 
     // Visit all nodes within the given rectangle boundary.
     pub(super) fn visit_nodes_in_rect<F>(&self, rect: &URect, visitor: &mut F, traversed: &mut u32)
     where
-        F: FnMut(&PNode<T, U>, &URect) -> bool,
+        F: FnMut(&PNode<T, U>, &URect) -> PNodeFill,
     {
         *traversed += 1;
 
         let sub_rect = self.region().intersect(rect);
         if !sub_rect.is_empty() {
-            if !visitor(self, &sub_rect) {
-                return;
-            }
+            let node_profile = visitor(self, &sub_rect);
             if let PNodeKind::Branch(children) = &self.kind {
-                for child in children.as_ref() {
-                    child.visit_nodes_in_rect(&sub_rect, visitor, traversed);
+                let node_profile = node_profile as u8;
+                for q in Quadrant::iter() {
+                    if node_profile & q.as_bit() != 0 {
+                        children[q as usize].visit_nodes_in_rect(rect, visitor, traversed);
+                    }
                 }
             }
         }
@@ -684,7 +784,6 @@ pub enum NeighborOrientation {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::Quadrant;
 
     #[test]
     fn test_subdivide() {
@@ -861,7 +960,7 @@ mod test {
             &n.region().into(),
             &mut |_n, _r| {
                 count += 1;
-                true
+                PNodeFill::Full
             },
             &mut 0,
         );

--- a/src/quadrant.rs
+++ b/src/quadrant.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 
 use crate::Direction;
 use bevy_math::UVec2;
@@ -7,6 +8,7 @@ use bevy_math::UVec2;
 /// A quadrant in a box.
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(usize)]
 pub enum Quadrant {
     BottomLeft = 0,
     BottomRight = 1,
@@ -15,6 +17,24 @@ pub enum Quadrant {
 }
 
 impl Quadrant {
+    /// Obtain an iterator over all [Quadrant] variants.
+    #[inline]
+    pub fn iter() -> impl Iterator<Item = Quadrant> {
+        [
+            Quadrant::BottomLeft,
+            Quadrant::BottomRight,
+            Quadrant::TopRight,
+            Quadrant::TopLeft,
+        ]
+        .into_iter()
+    }
+
+    /// The bit representation of the quadrant, which can be used in a bitmask.
+    #[inline]
+    pub const fn as_bit(&self) -> u8 {
+        1 << *self as u8
+    }
+
     /// Returns the quadrant for the given point in relation to the given center point.
     #[inline]
     #[must_use]
@@ -81,9 +101,135 @@ impl Quadrant {
     }
 }
 
+/// A [PixelMap] quad tree node fill pattern, regarding child node storage.
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[repr(u8)]
+pub enum PNodeFill {
+    /// ```text
+    /// oo
+    /// oo
+    /// ```
+    Empty = 0,
+
+    /// ```text
+    /// xx
+    /// xx
+    /// ```
+    Full = 0b1111,
+
+    /// ```text
+    /// xo
+    /// oo
+    /// ```
+    TopLeft = Quadrant::TopLeft.as_bit(),
+
+    /// ```text
+    /// ox
+    /// oo
+    /// ```
+    TopRight = Quadrant::TopRight.as_bit(),
+
+    /// ```text
+    /// oo
+    /// xo
+    /// ```
+    BottomLeft = Quadrant::BottomLeft.as_bit(),
+
+    /// ```text
+    /// oo
+    /// ox
+    /// ```
+    BottomRight = Quadrant::BottomRight.as_bit(),
+
+    /// ```text
+    /// xx
+    /// oo
+    /// ```
+    Top = Quadrant::TopLeft.as_bit() | Quadrant::TopRight.as_bit(),
+
+    /// ```text
+    /// oo
+    /// xx
+    /// ```
+    Bottom = Quadrant::BottomLeft.as_bit() | Quadrant::BottomRight.as_bit(),
+
+    /// ```text
+    /// xo
+    /// xo
+    /// ```
+    Left = Quadrant::BottomLeft.as_bit() | Quadrant::TopLeft.as_bit(),
+
+    /// ```text
+    /// ox
+    /// ox
+    /// ```
+    Right = Quadrant::BottomRight.as_bit() | Quadrant::TopRight.as_bit(),
+
+    /// ```text
+    /// ox
+    /// xo
+    /// ```
+    BottomRightTopLeft = Quadrant::BottomRight.as_bit() | Quadrant::TopLeft.as_bit(),
+
+    /// ```text
+    /// xo
+    /// ox
+    /// ```
+    BottomLeftTopRight = Quadrant::BottomLeft.as_bit() | Quadrant::TopRight.as_bit(),
+
+    /// ```text
+    /// ox
+    /// xx
+    /// ```
+    NotTopLeft = Quadrant::BottomLeft.as_bit()
+        | Quadrant::BottomRight.as_bit()
+        | Quadrant::TopRight.as_bit(),
+
+    /// ```text
+    /// xo
+    /// xx
+    /// ```
+    NotTopRight =
+        Quadrant::BottomLeft.as_bit() | Quadrant::BottomRight.as_bit() | Quadrant::TopLeft.as_bit(),
+
+    /// ```text
+    /// xx
+    /// ox
+    /// ```
+    NotBottomLeft =
+        Quadrant::BottomRight.as_bit() | Quadrant::TopLeft.as_bit() | Quadrant::TopRight.as_bit(),
+
+    /// ```text
+    /// xx
+    /// xo
+    /// ```
+    NotBottomRight =
+        Quadrant::BottomLeft.as_bit() | Quadrant::TopLeft.as_bit() | Quadrant::TopRight.as_bit(),
+}
+
+impl PNodeFill {
+    /// Negate the node fill pattern.
+    #[inline]
+    pub fn invert(&self) -> PNodeFill {
+        unsafe { std::mem::transmute(!(*self as u8) & 0b1111) }
+    }
+
+    /// If the fill represents a single quadrant, return that quadrant. `None`, otherwise.
+    pub fn quadrant(&self) -> Option<Quadrant> {
+        match self {
+            PNodeFill::TopLeft => Some(Quadrant::TopLeft),
+            PNodeFill::TopRight => Some(Quadrant::TopRight),
+            PNodeFill::BottomLeft => Some(Quadrant::BottomLeft),
+            PNodeFill::BottomRight => Some(Quadrant::BottomRight),
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::Quadrant;
+    use crate::PNodeFill;
 
     #[test]
     fn test_for_point() {
@@ -91,5 +237,15 @@ mod test {
         assert_eq!(Quadrant::for_point((1, 0), 1), Quadrant::BottomRight);
         assert_eq!(Quadrant::for_point((0, 1), 1), Quadrant::TopLeft);
         assert_eq!(Quadrant::for_point((1, 1), 1), Quadrant::TopRight);
+    }
+
+    #[test]
+    fn test_node_fill_invert() {
+        assert_eq!(PNodeFill::Full.invert(), PNodeFill::Empty);
+        assert_eq!(PNodeFill::Empty.invert(), PNodeFill::Full);
+        assert_eq!(PNodeFill::Left.invert(), PNodeFill::Right);
+        assert_eq!(PNodeFill::Right.invert(), PNodeFill::Left);
+        assert_eq!(PNodeFill::TopLeft.invert(), PNodeFill::NotTopLeft);
+        assert_eq!(PNodeFill::NotTopLeft.invert(), PNodeFill::TopLeft);
     }
 }


### PR DESCRIPTION
* Add `PNode::node_fill_profile(...) -> PNodeFill` for better understanding how a node is populated
  with pixel data.
* Allow more advanced tree navigation by producing a `PNodeFill` from a `PixelMap::visit_nodes_in_rect`
  visitor closure, rather than a `bool`, which controls child node visitation.